### PR TITLE
move-sorting-in-database

### DIFF
--- a/src/main/java/com/bg/bassheadsbg/repository/MultiChannelAmplifierRepository.java
+++ b/src/main/java/com/bg/bassheadsbg/repository/MultiChannelAmplifierRepository.java
@@ -1,10 +1,11 @@
 package com.bg.bassheadsbg.repository;
 
-import com.bg.bassheadsbg.model.entity.amplifiers.MonoAmplifier;
 import com.bg.bassheadsbg.model.entity.amplifiers.MultiChannelAmplifier;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -12,4 +13,12 @@ import java.util.Optional;
 public interface MultiChannelAmplifierRepository
         extends JpaRepository<MultiChannelAmplifier, Long> {
     Optional<MultiChannelAmplifier> findByBrandAndModel(String brand, String model);
+
+    @Query("SELECT mc FROM MultiChannelAmplifier mc " +
+            "LEFT JOIN mc.userLikes mcul " +
+            "GROUP BY mc.id " +
+            "ORDER BY COUNT(mcul.id) DESC, " +
+            "LOWER(mc.brand) ASC, " +
+            "LOWER(mc.model) ASC")
+    List<MultiChannelAmplifier> findAllMultiChannelAmpsUserLikesCountOrderByBrandAndModel();
 }

--- a/src/main/java/com/bg/bassheadsbg/repository/PowerCableRepository.java
+++ b/src/main/java/com/bg/bassheadsbg/repository/PowerCableRepository.java
@@ -2,12 +2,22 @@ package com.bg.bassheadsbg.repository;
 
 import com.bg.bassheadsbg.model.entity.cables.PowerCable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PowerCableRepository extends JpaRepository<PowerCable, Long> {
     Optional<PowerCable> findByMaterial(String material);
     Optional<PowerCable> findByBrandAndModel(String brand, String model);
+
+    @Query("SELECT pc FROM PowerCable pc " +
+            "LEFT JOIN pc.userLikes pcul " +
+            "GROUP BY pc.id " +
+            "ORDER BY COUNT(pcul.id) DESC, " +
+            "LOWER(pc.brand) ASC, " +
+            "LOWER(pc.model) ASC")
+    List<PowerCable> findAllPowerCablesUserLikesCountOrderByBrandAndModel();
 }

--- a/src/main/java/com/bg/bassheadsbg/service/implementation/HighRangeServiceImpl.java
+++ b/src/main/java/com/bg/bassheadsbg/service/implementation/HighRangeServiceImpl.java
@@ -1,10 +1,6 @@
 package com.bg.bassheadsbg.service.implementation;
 
-import com.bg.bassheadsbg.exception.DeviceAlreadyExistsException;
-import com.bg.bassheadsbg.exception.DeviceAlreadyLikedException;
-import com.bg.bassheadsbg.exception.DeviceNotFoundException;
-import com.bg.bassheadsbg.exception.UserNotAuthenticatedException;
-import com.bg.bassheadsbg.exception.UserNotFoundException;
+import com.bg.bassheadsbg.exception.*;
 import com.bg.bassheadsbg.kafka.ImageProducer;
 import com.bg.bassheadsbg.messages.ExceptionMessages;
 import com.bg.bassheadsbg.model.dto.add.AddHighRangeDTO;
@@ -167,9 +163,10 @@ public class HighRangeServiceImpl implements HighRangeService {
     @Transactional
     @Override
     public List<HighRangeSummaryDTO> getAllSpeakersSummarySorted() {
-        List<HighRange> highRangesList = highRangeRepository.findAllHighRangesWithUserLikesCountOrderByBrandAndModel();
-
-        return highRangesList.stream().map(this::mapHighRangeToHighRangeSummaryDTO).toList();
+        return highRangeRepository.findAllHighRangesWithUserLikesCountOrderByBrandAndModel()
+                .stream()
+                .map(this::mapHighRangeToHighRangeSummaryDTO)
+                .toList();
     }
 
     /**

--- a/src/main/java/com/bg/bassheadsbg/service/implementation/MidRangeServiceImpl.java
+++ b/src/main/java/com/bg/bassheadsbg/service/implementation/MidRangeServiceImpl.java
@@ -127,8 +127,8 @@ public class MidRangeServiceImpl implements MidRangeService {
     @Transactional
     @Override
     public List<MidRangeSummaryDTO> getAllSpeakersSummarySorted() {
-        List<MidRange> midRangesList = midRangeRepository.findAllMidRangesWithUserLikesCountOrderByBrandAndModel();
-        return midRangesList.stream()
+        return midRangeRepository.findAllMidRangesWithUserLikesCountOrderByBrandAndModel()
+                .stream()
                 .map(this::mapMidRangeToMidRangeSummaryDTO)
                 .toList();
     }

--- a/src/main/java/com/bg/bassheadsbg/service/implementation/MonoAmpServiceImpl.java
+++ b/src/main/java/com/bg/bassheadsbg/service/implementation/MonoAmpServiceImpl.java
@@ -132,9 +132,8 @@ public class MonoAmpServiceImpl implements MonoAmpService {
     @Transactional
     @Override
     public List<MonoAmpSummaryDTO> getAllAmplifiersSummarySorted() {
-        List<MonoAmplifier> monoAmplifiersList = monoAmplifierRepository.findAllMonoAmplifiersCountUserLikesOrderByBrandAndModel();
-
-        return monoAmplifiersList.stream()
+        return monoAmplifierRepository.findAllMonoAmplifiersCountUserLikesOrderByBrandAndModel()
+                .stream()
                 .map(this::mapMonoAmpToMonoAmpSummaryDTO)
                 .toList();
     }

--- a/src/main/java/com/bg/bassheadsbg/service/implementation/MultiChannelAmpServiceImpl.java
+++ b/src/main/java/com/bg/bassheadsbg/service/implementation/MultiChannelAmpServiceImpl.java
@@ -1,17 +1,13 @@
 package com.bg.bassheadsbg.service.implementation;
 
-import com.bg.bassheadsbg.exception.DeviceAlreadyExistsException;
-import com.bg.bassheadsbg.exception.DeviceAlreadyLikedException;
-import com.bg.bassheadsbg.exception.DeviceNotFoundException;
-import com.bg.bassheadsbg.exception.UserNotAuthenticatedException;
-import com.bg.bassheadsbg.exception.UserNotFoundException;
+import com.bg.bassheadsbg.exception.*;
 import com.bg.bassheadsbg.kafka.ImageProducer;
 import com.bg.bassheadsbg.messages.ExceptionMessages;
 import com.bg.bassheadsbg.model.dto.add.AddMultiChannelAmpDTO;
 import com.bg.bassheadsbg.model.dto.details.MultiChannelAmpDetailsDTO;
 import com.bg.bassheadsbg.model.dto.summary.MultiChannelAmpSummaryDTO;
-import com.bg.bassheadsbg.model.entity.images.MultiChannelAmplifierImage;
 import com.bg.bassheadsbg.model.entity.amplifiers.MultiChannelAmplifier;
+import com.bg.bassheadsbg.model.entity.images.MultiChannelAmplifierImage;
 import com.bg.bassheadsbg.model.entity.users.UserEntity;
 import com.bg.bassheadsbg.model.helpers.MultiChannelAmpDetailsHelperDTO;
 import com.bg.bassheadsbg.repository.MultiChannelAmplifierImageRepository;
@@ -34,7 +30,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -131,24 +126,11 @@ public class MultiChannelAmpServiceImpl implements MultiChannelAmpService {
 
     @Transactional
     @Override
-    public List<MultiChannelAmpSummaryDTO> getAllAmplifierSummary() {
-        return multiChannelAmplifierRepository.findAll()
-                .stream()
-                .sorted(Comparator
-                        .comparingLong(MultiChannelAmplifier::getLikes)
-                        .reversed()
-                        .thenComparing(a -> a.getBrand().toLowerCase())
-                        .thenComparing(a -> a.getModel().toLowerCase()))
-                .map(multiChannelAmplifier -> {
-                    MultiChannelAmpSummaryDTO summaryDTO = modelMapper.map(multiChannelAmplifier, MultiChannelAmpSummaryDTO.class);
-                    summaryDTO.setLikes(multiChannelAmplifier.getLikes());
-
-                    MultiChannelAmplifierImage firstImage = multiChannelAmplifier.getImageFiles().get(0);
-                    String base64Image = Base64.getEncoder().encodeToString(firstImage.getImageData());
-                    summaryDTO.setImageFile(base64Image);
-                    return summaryDTO;
-                })
-                .toList();
+    public List<MultiChannelAmpSummaryDTO> getAllAmplifiersSummarySorted() {
+       List<MultiChannelAmplifier> multiChannelAmplifiersList = multiChannelAmplifierRepository.findAllMultiChannelAmpsUserLikesCountOrderByBrandAndModel();
+       return multiChannelAmplifiersList.stream()
+               .map(this::mapMultiChannelAmpToMultiChannelAmpSummaryDTO)
+               .toList();
     }
 
     @Transactional
@@ -255,6 +237,14 @@ public class MultiChannelAmpServiceImpl implements MultiChannelAmpService {
                     multiChannelAmplifier.getBrand(),
                     multiChannelAmplifier.getModel());
         }
+    }
+
+    private MultiChannelAmpSummaryDTO mapMultiChannelAmpToMultiChannelAmpSummaryDTO(MultiChannelAmplifier multiChannelAmp) {
+        MultiChannelAmpSummaryDTO multiChannelAmpSummaryDTO = modelMapper.map(multiChannelAmp, MultiChannelAmpSummaryDTO.class);
+        multiChannelAmpSummaryDTO.setLikes(multiChannelAmp.getLikes());
+        byte[] image = multiChannelAmp.getImageFiles().get(0).getImageData();
+        multiChannelAmpSummaryDTO.setImageFile(Base64.getEncoder().encodeToString(image));
+        return multiChannelAmpSummaryDTO;
     }
 
     private static UserDetails getPrincipal() {

--- a/src/main/java/com/bg/bassheadsbg/service/implementation/MultiChannelAmpServiceImpl.java
+++ b/src/main/java/com/bg/bassheadsbg/service/implementation/MultiChannelAmpServiceImpl.java
@@ -127,8 +127,8 @@ public class MultiChannelAmpServiceImpl implements MultiChannelAmpService {
     @Transactional
     @Override
     public List<MultiChannelAmpSummaryDTO> getAllAmplifiersSummarySorted() {
-       List<MultiChannelAmplifier> multiChannelAmplifiersList = multiChannelAmplifierRepository.findAllMultiChannelAmpsUserLikesCountOrderByBrandAndModel();
-       return multiChannelAmplifiersList.stream()
+       return multiChannelAmplifierRepository.findAllMultiChannelAmpsUserLikesCountOrderByBrandAndModel()
+               .stream()
                .map(this::mapMultiChannelAmpToMultiChannelAmpSummaryDTO)
                .toList();
     }

--- a/src/main/java/com/bg/bassheadsbg/service/implementation/PowerCableServiceImpl.java
+++ b/src/main/java/com/bg/bassheadsbg/service/implementation/PowerCableServiceImpl.java
@@ -1,10 +1,6 @@
 package com.bg.bassheadsbg.service.implementation;
 
-import com.bg.bassheadsbg.exception.DeviceAlreadyExistsException;
-import com.bg.bassheadsbg.exception.DeviceAlreadyLikedException;
-import com.bg.bassheadsbg.exception.DeviceNotFoundException;
-import com.bg.bassheadsbg.exception.UserNotAuthenticatedException;
-import com.bg.bassheadsbg.exception.UserNotFoundException;
+import com.bg.bassheadsbg.exception.*;
 import com.bg.bassheadsbg.messages.ExceptionMessages;
 import com.bg.bassheadsbg.model.dto.add.AddPowerCableDTO;
 import com.bg.bassheadsbg.model.dto.details.PowerCableDetailsDTO;
@@ -31,11 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -128,25 +120,10 @@ public class PowerCableServiceImpl implements PowerCableService {
 
     @Override
     @Transactional
-    public List<PowerCableSummaryDTO> getAllCableSummary() {
-
-        return powerCableRepository.findAll()
+    public List<PowerCableSummaryDTO> getAllPowerCablesSummarySorted() {
+        return powerCableRepository.findAllPowerCablesUserLikesCountOrderByBrandAndModel()
                 .stream()
-                .sorted(Comparator
-                        .comparingLong(PowerCable::getLikes)
-                        .reversed()
-                        .thenComparing(a -> a.getBrand().toLowerCase())
-                        .thenComparing(a -> a.getModel().toLowerCase())
-                )
-                .map(powerCable -> {
-                    PowerCableSummaryDTO summaryDTO = modelMapper.map(powerCable, PowerCableSummaryDTO.class);
-                    summaryDTO.setLikes(powerCable.getLikes());
-
-                    PowerCableImage firstImage = powerCable.getImageFiles().get(0);
-                    String base64Image = Base64.getEncoder().encodeToString(firstImage.getImageData());
-                    summaryDTO.setImageFile(base64Image);
-                    return summaryDTO;
-                })
+                .map(this::mapPowerCableToPowerCableSummaryDTO)
                 .toList();
     }
 
@@ -255,6 +232,14 @@ public class PowerCableServiceImpl implements PowerCableService {
                     powerCable.getBrand(),
                     powerCable.getModel());
         }
+    }
+
+    private PowerCableSummaryDTO mapPowerCableToPowerCableSummaryDTO(PowerCable powerCable) {
+        PowerCableSummaryDTO powerCableSummaryDTO = modelMapper.map(powerCable, PowerCableSummaryDTO.class);
+        powerCableSummaryDTO.setLikes(powerCable.getLikes());
+        byte[] image = powerCable.getImageFiles().get(0).getImageData();
+        powerCableSummaryDTO.setImageFile(Base64.getEncoder().encodeToString(image));
+        return powerCableSummaryDTO;
     }
 
     private static UserDetails getPrincipal() {

--- a/src/main/java/com/bg/bassheadsbg/service/implementation/SubwooferServiceImpl.java
+++ b/src/main/java/com/bg/bassheadsbg/service/implementation/SubwooferServiceImpl.java
@@ -127,8 +127,9 @@ public class SubwooferServiceImpl implements SubwooferService {
     @Transactional
     @Override
     public List<SubwooferSummaryDTO> getAllSpeakersSummarySorted() {
-        List<Subwoofer> subwooferList = subwooferRepository.findAllSubwoofersWithUserLikesCountOrderByBrandAndModel();
-        return subwooferList.stream().map(this::mapSubwooferToSubwooferSummaryDTO)
+        return subwooferRepository.findAllSubwoofersWithUserLikesCountOrderByBrandAndModel()
+                .stream()
+                .map(this::mapSubwooferToSubwooferSummaryDTO)
                 .toList();
     }
 

--- a/src/main/java/com/bg/bassheadsbg/service/interfaces/MultiChannelAmpService.java
+++ b/src/main/java/com/bg/bassheadsbg/service/interfaces/MultiChannelAmpService.java
@@ -4,7 +4,6 @@ import com.bg.bassheadsbg.model.dto.add.AddMultiChannelAmpDTO;
 import com.bg.bassheadsbg.model.dto.details.MultiChannelAmpDetailsDTO;
 import com.bg.bassheadsbg.model.dto.summary.MultiChannelAmpSummaryDTO;
 import com.bg.bassheadsbg.model.helpers.MultiChannelAmpDetailsHelperDTO;
-import jakarta.transaction.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -20,7 +19,7 @@ public interface MultiChannelAmpService {
 
     void deleteAmplifier(long amplifierId);
 
-    List<MultiChannelAmpSummaryDTO> getAllAmplifierSummary();
+    List<MultiChannelAmpSummaryDTO> getAllAmplifiersSummarySorted();
 
     MultiChannelAmpDetailsDTO getAmplifierDetails(Long id);
 

--- a/src/main/java/com/bg/bassheadsbg/service/interfaces/PowerCableService.java
+++ b/src/main/java/com/bg/bassheadsbg/service/interfaces/PowerCableService.java
@@ -3,13 +3,11 @@ package com.bg.bassheadsbg.service.interfaces;
 import com.bg.bassheadsbg.model.dto.add.AddPowerCableDTO;
 import com.bg.bassheadsbg.model.dto.details.PowerCableDetailsDTO;
 import com.bg.bassheadsbg.model.dto.summary.PowerCableSummaryDTO;
-import com.bg.bassheadsbg.model.entity.cables.PowerCable;
 import com.bg.bassheadsbg.model.helpers.PowerCableDetailsHelperDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 public interface PowerCableService {
 
@@ -21,7 +19,7 @@ public interface PowerCableService {
 
     void deleteCable(long cableId);
 
-    List<PowerCableSummaryDTO> getAllCableSummary();
+    List<PowerCableSummaryDTO> getAllPowerCablesSummarySorted();
 
     PowerCableDetailsDTO getCableDetails(Long id);
 

--- a/src/main/java/com/bg/bassheadsbg/web/controller/amplifierControllers/MultiChannelAmplifierController.java
+++ b/src/main/java/com/bg/bassheadsbg/web/controller/amplifierControllers/MultiChannelAmplifierController.java
@@ -2,7 +2,6 @@ package com.bg.bassheadsbg.web.controller.amplifierControllers;
 
 import com.bg.bassheadsbg.model.dto.add.AddMultiChannelAmpDTO;
 import com.bg.bassheadsbg.service.interfaces.MultiChannelAmpService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.validation.Valid;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -79,7 +78,7 @@ public class MultiChannelAmplifierController {
 
     @GetMapping("/rankings")
     public String rankings(Model model) {
-        model.addAttribute("allDevices", multiChannelAmpService.getAllAmplifierSummary());
+        model.addAttribute("allDevices", multiChannelAmpService.getAllAmplifiersSummarySorted());
         return "amplifiers/multichannel-amp-all";
     }
 

--- a/src/main/java/com/bg/bassheadsbg/web/controller/cableControllers/PowerCableController.java
+++ b/src/main/java/com/bg/bassheadsbg/web/controller/cableControllers/PowerCableController.java
@@ -80,7 +80,7 @@ public class PowerCableController {
 
     @GetMapping("/rankings")
     public String rankings(Model model) {
-        model.addAttribute("allCables", powerCableService.getAllCableSummary());
+        model.addAttribute("allCables", powerCableService.getAllPowerCablesSummarySorted());
         return "cables/powercable-all";
     }
 


### PR DESCRIPTION
Move sort logic for multichannel amplifiers in database, instead of the backend
- Reduce boilerplate code in other services.